### PR TITLE
Fix Library name; Rename psutils => psutil everywhere in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Simply clone this git repo using your favorite method. Using the git CLI you can
 ### Dependencies
 * Python 3 or higher
 * Flask
-* psutils
+* psutil
 * xmr-btc-swap SWAP CLI
 
-**swapfe** requires two extra dependencies to be able to run correclty. These are **Flask** and **psutils**. Issue the following comands in your console to install these requried packages. 
+**swapfe** requires two extra dependencies to be able to run correclty. These are **Flask** and **psutil**. Issue the following comands in your console to install these requried packages. 
 
 `pip install Flask`
-`pip install psutils`
+`pip install psutil`
 
 You must download the Swap CLI from Comit-network and install it in the directory where **swapfe** resides. For \*NIX users you can download that by issuing the following command in your console:
 


### PR DESCRIPTION
psutils isn't a package:

![image](https://user-images.githubusercontent.com/32943174/135615650-20d4f7af-9c0f-4c65-821e-6c8b4b49dbe0.png)

psutil is: https://pypi.org/project/psutil/

swapfe.py references psutil, not psutils